### PR TITLE
refactor: move provisional order commit to thunk

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/src/views.jsx
+++ b/src/views.jsx
@@ -196,19 +196,8 @@ function OptionsList() {
       const pas = clamp(getPas(ev.clientX), option.askPAS, option.bidPAS);
       dispatch(actions.setProvisional({ ...p, qty, pas }));
     }
-    function up() { window.removeEventListener('mousemove', mm); window.removeEventListener('mouseup', up); commit(option); }
+    function up() { window.removeEventListener('mousemove', mm); window.removeEventListener('mouseup', up); dispatch(actions.commitProvisional(option)); }
     window.addEventListener('mousemove', mm); window.addEventListener('mouseup', up);
-  }
-
-  async function commit(option) {
-    const st = store.getState();
-    const provisional = st.orders.provisional; if (!provisional) return;
-    const premium = Math.round((option.strike + st.orders.commission - provisional.pas) * 100) / 100;
-    const qty = provisional.qty; const pas = provisional.pas;
-    dispatch(actions.clearProvisional());
-    const res = await broker.openOrder({ option: { ...option }, limitPrice: premium, qty });
-    if (res?.ok) dispatch(actions.addOpenOrder({ id: res.orderId, optionId: option.id, qty, limitPrice: premium, pas }));
-    else alert('Order not filled (simulated). Try closer to bid or higher bid size.');
   }
 
   const price = useSelector(s => selectMarket(s).price);


### PR DESCRIPTION
## Summary
- centralize provisional order execution in commitProvisional thunk
- dispatch commitProvisional from OptionsList drag handler
- ignore node_modules in git

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b15585cfb0832485e92c1ae08960ca