### PR TITLE
refactor: move cancel order to thunk

### DIFF
--- a/src/logic.js
+++ b/src/logic.js
@@ -57,11 +57,22 @@ export const commitProvisional = (option) => async (dispatch, getState) => {
   }
 };
 
+// thunk to cancel an open order
+export const cancelOpenOrder = (id) => async (dispatch) => {
+  const res = await broker.cancelOrder(id);
+  if (res?.ok) {
+    dispatch(ordersSlice.actions.removeOpenOrder(id));
+  } else {
+    alert('Cancel failed (mock)');
+  }
+};
+
 export const actions = {
   ...marketSlice.actions,
   ...ordersSlice.actions,
   ...settingsSlice.actions,
-  commitProvisional
+  commitProvisional,
+  cancelOpenOrder
 };
 
 export const store = configureStore({

--- a/src/views.jsx
+++ b/src/views.jsx
@@ -89,12 +89,6 @@ function PriceAxis({ onHeight, axisH }) {
   const prov = useSelector(s => selectOrders(s).provisional);
   const openOrders = useSelector(s => selectOrders(s).openOrders);
 
-  async function cancel(id) {
-    const res = await broker.cancelOrder(id);
-    if (res?.ok) dispatch(actions.removeOpenOrder(id));
-    else alert('Cancel failed (mock)');
-  }
-
   const group0 = [];
   if (bounds.min != null) group0.push({ key: 'min', x: pas2x(bounds.min), text: `$${bounds.min}`, color: 'white' });
   if (bounds.max != null) group0.push({ key: 'max', x: pas2x(bounds.max), text: `$${bounds.max}`, color: 'white' });
@@ -102,7 +96,7 @@ function PriceAxis({ onHeight, axisH }) {
   const group1 = [{ key: 'm', x: pas2x(price), text: `$${price.toFixed(2)}`, color: pClr }];
 
   const group2 = [];
-  openOrders.forEach(o => group2.push({ key: 'o-' + o.id, x: pas2x(o.pas), text: `${o.qty} × $${o.pas.toFixed(2)}`, color: 'yellow', onTrash: () => cancel(o.id) }));
+  openOrders.forEach(o => group2.push({ key: 'o-' + o.id, x: pas2x(o.pas), text: `${o.qty} × $${o.pas.toFixed(2)}`, color: 'yellow', onTrash: () => dispatch(actions.cancelOpenOrder(o.id)) }));
   if (prov) group2.push({ key: 'p', x: pas2x(prov.pas), text: `${prov.qty} × $${prov.pas.toFixed(2)}`, color: 'blue' });
 
   const { placed: tags, totalRows } = layoutTagsGrouped([group0, group1, group2], width);


### PR DESCRIPTION
## Summary
- move cancel side effects out of `views.jsx`
- add `cancelOpenOrder` thunk in `logic.js` and invoke from UI

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68b194924cf483249d83620ab58370b7