### PR TITLE
Compute PAS dynamically from option premiums

### DIFF
--- a/src/broker.js
+++ b/src/broker.js
@@ -88,7 +88,6 @@ function mkBroker(seed = 42) {
 }
 
 function synthOptions(under, now) {
-  const commission = 0.75;
   const MIN_PREMIUM_SPREAD = 7;
   const arr = [];
   const startStrike = Math.ceil(under * 1.01);
@@ -109,17 +108,13 @@ function synthOptions(under, now) {
     const depth = (strike - under) / Math.max(under * 0.01, 0.5);
     const sigmoid = 1 / (1 + Math.exp(-0.6 * depth));
     const probITM = clamp(0.65 + 0.35 * sigmoid + 0.05 * (bidSize / 20), 0.5, 0.995);
-    const askPAS = strike - askPremium + commission;
-    const bidPAS = strike - bidPremium + commission;
     arr.push({
       id: `put-${strike}`,
       strike,
       bidSize,
       probITM: Math.round(probITM * 100),
       askPremium: round2(askPremium),
-      bidPremium: round2(bidPremium),
-      askPAS: round2(askPAS),
-      bidPAS: round2(bidPAS)
+      bidPremium: round2(bidPremium)
     });
   }
   return arr;

--- a/src/logic.js
+++ b/src/logic.js
@@ -1,6 +1,6 @@
 import { configureStore, createSlice } from '@reduxjs/toolkit';
 import { createSelector } from 'reselect';
-import { niceStep } from './util';
+import { niceStep, computeAskPas, computeBidPas } from './util';
 import broker from './broker';
 
 const marketSlice = createSlice({
@@ -84,8 +84,17 @@ export const selectOrders = (s) => s.orders;
 export const selectSettings = (s) => s.settings;
 export const selectPriceRange = (s) => s.market.priceRange;
 
+export const selectOptionsWithPas = createSelector(
+  [s => s.market.options, selectOrders],
+  (opts, orders) => (opts || []).map(o => ({
+    ...o,
+    askPAS: computeAskPas(o.strike, o.askPremium, orders.commission),
+    bidPAS: computeBidPas(o.strike, o.bidPremium, orders.commission)
+  }))
+);
+
 export const selectFilteredOptions = createSelector(
-  [s => s.market.options, selectSettings],
+  [selectOptionsWithPas, selectSettings],
   (opts, settings) => (opts || []).filter(o => o.probITM >= settings.minProbITM && o.bidSize >= settings.minBidSize)
 );
 

--- a/src/util.js
+++ b/src/util.js
@@ -1,5 +1,11 @@
 export const clamp = (v, lo, hi) => Math.max(lo, Math.min(hi, v));
 
+export const computeAskPas = (strike, askPremium, commission) =>
+  Math.round((strike - askPremium + commission) * 100) / 100;
+
+export const computeBidPas = (strike, bidPremium, commission) =>
+  Math.round((strike - bidPremium + commission) * 100) / 100;
+
 export const TAG_ROW_H = 24;
 export const TAG_TOP_PAD = 6;
 export const TAG_HEIGHT = 22;

--- a/src/views.jsx
+++ b/src/views.jsx
@@ -174,12 +174,13 @@ function OptionsList() {
     e.preventDefault();
     const rect = ref.current.getBoundingClientRect();
     const startY = e.clientY; const startQty = 1;
+    const { askPAS, bidPAS } = option;
     const getPas = (clientX) => {
       const localX = clientX - rect.left;
       const s = store.getState(); const r = selectPriceRange(s); const span = r.max - r.min;
       return Math.round((r.min + (localX / Math.max(1, width)) * span) * 100) / 100;
     };
-    const startPas = clamp(getPas(e.clientX), option.askPAS, option.bidPAS);
+    const startPas = clamp(getPas(e.clientX), askPAS, bidPAS);
     const p = { id: `prov-${Date.now()}`, optionId: option.id, limitPrice: option.askPremium, pas: startPas, qty: startQty, strike: option.strike };
     dispatch(actions.setProvisional(p));
 
@@ -187,7 +188,7 @@ function OptionsList() {
       const dy = ev.clientY - startY;
       const deltaQty = Math.floor(-dy / (height * 0.05));
       const qty = Math.max(1, startQty + deltaQty);
-      const pas = clamp(getPas(ev.clientX), option.askPAS, option.bidPAS);
+      const pas = clamp(getPas(ev.clientX), askPAS, bidPAS);
       dispatch(actions.setProvisional({ ...p, qty, pas }));
     }
     function up() { window.removeEventListener('mousemove', mm); window.removeEventListener('mouseup', up); dispatch(actions.commitProvisional(option)); }

--- a/tests/pas.test.js
+++ b/tests/pas.test.js
@@ -1,0 +1,29 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { store, actions, selectFilteredOptions, selectOptionPasBounds } from '../src/logic';
+
+describe('PAS computation', () => {
+  it('derives PAS values when missing from broker data', () => {
+    const option = {
+      id: 'put-101',
+      strike: 101,
+      bidSize: 10,
+      probITM: 90,
+      askPremium: 7,
+      bidPremium: 6.5
+    };
+    store.dispatch(actions.streamUpdate({ price: 100, now: 0, options: [option] }));
+    const opts = selectFilteredOptions(store.getState());
+    expect(opts).toHaveLength(1);
+    const computed = opts[0];
+    const commission = store.getState().orders.commission;
+    expect(computed.askPAS).toBeCloseTo(101 - 7 + commission, 2);
+    expect(computed.bidPAS).toBeCloseTo(101 - 6.5 + commission, 2);
+    const bounds = selectOptionPasBounds(store.getState());
+    expect(bounds.min).toBeCloseTo(computed.askPAS, 2);
+    expect(bounds.max).toBeCloseTo(computed.bidPAS, 2);
+  });
+});
+
+afterEach(() => {
+  store.dispatch(actions.streamUpdate({ price: 100, now: 0, options: [] }));
+});


### PR DESCRIPTION
## Summary
- derive ask/bid PAS on the fly using commission and premiums
- enrich selectors with computed PAS and update views
- add tests ensuring PAS is computed when broker omits fields

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b1a9508718832486f78cb17f5e5217