### PR TITLE
Refine mergeOrders reducer and isolate tests

### DIFF
--- a/src/logic.js
+++ b/src/logic.js
@@ -23,6 +23,16 @@ const marketSlice = createSlice({
   }
 });
 
+const ORDER_FIELDS = ['status', 'quantity', 'commission', 'limit'];
+
+const applyOrderFields = (target, update) => {
+  for (const field of ORDER_FIELDS) {
+    if (Object.prototype.hasOwnProperty.call(update, field)) {
+      target[field] = update[field];
+    }
+  }
+};
+
 const ordersSlice = createSlice({
   name: 'orders',
   initialState: { commission: 0.75, availableCash: 100000, openOrders: [], provisional: null },
@@ -30,7 +40,26 @@ const ordersSlice = createSlice({
     setProvisional(s, a) { s.provisional = a.payload; },
     clearProvisional(s) { s.provisional = null; },
     addOpenOrder(s, a) { s.openOrders.push(a.payload); },
-    removeOpenOrder(s, a) { s.openOrders = s.openOrders.filter(o => o.id !== a.payload); }
+    removeOpenOrder(s, a) { s.openOrders = s.openOrders.filter(o => o.id !== a.payload); },
+    mergeOrders(s, a) {
+      const updates = Array.isArray(a.payload) ? a.payload : [];
+      if (!updates.length) return;
+
+      const byId = new Map(s.openOrders.map(order => [order.id, order]));
+
+      for (const upd of updates) {
+        if (!upd || upd.id === undefined || upd.id === null) continue;
+        const existing = byId.get(upd.id);
+        if (existing) {
+          applyOrderFields(existing, upd);
+        } else {
+          const newOrder = { id: upd.id };
+          applyOrderFields(newOrder, upd);
+          s.openOrders.push(newOrder);
+          byId.set(newOrder.id, newOrder);
+        }
+      }
+    }
   }
 });
 
@@ -74,6 +103,8 @@ export const actions = {
   commitProvisional,
   cancelOpenOrder
 };
+
+export const ordersReducer = ordersSlice.reducer;
 
 export const store = configureStore({
   reducer: { market: marketSlice.reducer, orders: ordersSlice.reducer, settings: settingsSlice.reducer }

--- a/tests/mergeOrders.test.js
+++ b/tests/mergeOrders.test.js
@@ -1,0 +1,81 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { configureStore } from '@reduxjs/toolkit';
+import { actions, ordersReducer } from '../src/logic';
+
+const createStore = () => configureStore({ reducer: { orders: ordersReducer } });
+
+describe('mergeOrders reducer', () => {
+  let store;
+  const getOrder = (id) => store.getState().orders.openOrders.find(o => o.id === id);
+
+  beforeEach(() => {
+    store = createStore();
+  });
+
+  it('adds new orders with the provided fields', () => {
+    store.dispatch(actions.mergeOrders([
+      { id: '1', status: 'open', quantity: 10 }
+    ]));
+
+    const order = getOrder('1');
+    expect(order).toEqual({ id: '1', status: 'open', quantity: 10 });
+  });
+
+  it('adds payload orders that are absent from state without disturbing existing ones', () => {
+    store.dispatch(actions.mergeOrders([
+      { id: '1', status: 'open', quantity: 10, commission: 0.5, limit: 100 }
+    ]));
+
+    store.dispatch(actions.mergeOrders([
+      { id: '1', quantity: 7 },
+      { id: '2', status: 'open', quantity: 3, commission: 0.25 }
+    ]));
+
+    const openOrders = store.getState().orders.openOrders;
+    expect(openOrders).toHaveLength(2);
+    expect(getOrder('1')).toEqual({ id: '1', status: 'open', quantity: 7, commission: 0.5, limit: 100 });
+    expect(getOrder('2')).toEqual({ id: '2', status: 'open', quantity: 3, commission: 0.25 });
+  });
+
+  it('updates each explicit field on an existing order', () => {
+    store.dispatch(actions.mergeOrders([
+      { id: '1', status: 'open', quantity: 10, commission: 0.5, limit: 100 }
+    ]));
+
+    store.dispatch(actions.mergeOrders([
+      { id: '1', status: 'filled', quantity: 7, commission: 1.25, limit: 120 }
+    ]));
+
+    const order = getOrder('1');
+    expect(order).toEqual({ id: '1', status: 'filled', quantity: 7, commission: 1.25, limit: 120 });
+  });
+
+  it('does not remove existing field values when updates omit them', () => {
+    store.dispatch(actions.mergeOrders([
+      { id: '1', status: 'open', quantity: 10, commission: 0.5, limit: 100 }
+    ]));
+
+    store.dispatch(actions.mergeOrders([
+      { id: '1', status: 'filled' }
+    ]));
+
+    const order = getOrder('1');
+    expect(order).toEqual({ id: '1', status: 'filled', quantity: 10, commission: 0.5, limit: 100 });
+  });
+
+  it('does not remove orders that are missing from an update payload', () => {
+    store.dispatch(actions.mergeOrders([
+      { id: '1', status: 'open', quantity: 10 },
+      { id: '2', status: 'open', quantity: 5 }
+    ]));
+
+    store.dispatch(actions.mergeOrders([
+      { id: '1', quantity: 8 }
+    ]));
+
+    const openOrders = store.getState().orders.openOrders;
+    expect(openOrders).toHaveLength(2);
+    expect(getOrder('1')).toEqual({ id: '1', status: 'open', quantity: 8 });
+    expect(getOrder('2')).toEqual({ id: '2', status: 'open', quantity: 5 });
+  });
+});


### PR DESCRIPTION
## Summary
- extract a helper that copies the known order fields so mergeOrders can share logic for existing and new orders
- memoize existing orders by id during a merge to avoid repeated scans and export the reducer for isolated testing
- build fresh stores in mergeOrders tests to eliminate state bleed between cases

## Testing
- `npm test -- run`


------
https://chatgpt.com/codex/tasks/task_e_68c697d344388324adbd640db84a1695